### PR TITLE
error al crear projects

### DIFF
--- a/sql/swad.sql
+++ b/sql/swad.sql
@@ -959,7 +959,7 @@ CREATE TABLE IF NOT EXISTS projects (
 	INDEX(CrsCod,Hidden),
 	INDEX(CrsCod,CreatTime),
 	INDEX(CrsCod,ModifTime),
-	INDEX(CrsCod,DptCod);
+	INDEX(CrsCod,DptCod));
 --
 -- Table sessions: stores the information of open sessions
 --


### PR DESCRIPTION
Añadido el parentesis de cierre de la orden CREATE TABLE en la tabla projects